### PR TITLE
Fix AssertionRequirementHandler service resolving

### DIFF
--- a/Cloudey.Reflex.Authorization/DependencyInjectionExtensions.cs
+++ b/Cloudey.Reflex.Authorization/DependencyInjectionExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Reflection;
 using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Authorization.Infrastructure;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Cloudey.Reflex.Authorization;
@@ -18,7 +19,9 @@ public static class DependencyInjectionExtensions
         services.AddAuthorizationCore(configure ?? (_ => { }));
         services.AddSingleton<IAuthorizationPolicyProvider, AuthorizationPolicyProvider>();
         services.AddSingleton<IAuthorizationHandlerProvider, AuthorizationHandlerProvider>();
-        services.AddSingleton<IAuthorizationHandler, AssertionRequirementHandler>();
+        services.AddSingleton<AssertionRequirementHandler>();
+        services.AddSingleton<AuthorizationHandler<AssertionRequirement>>(provider => provider.GetRequiredService<AssertionRequirementHandler>());
+        services.AddSingleton<IAuthorizationHandler>(provider => provider.GetRequiredService<AssertionRequirementHandler>());
         services.AddSingleton<IAuthorizationService, AuthorizationService>();
 
         foreach (var assembly in assemblies)


### PR DESCRIPTION
I ran into an issue resulting in assertion handlers not being applied and thus failing the whole authorization process.
The key cause for that was this line:

https://github.com/CloudeyIT/Reflex/blob/master/Cloudey.Reflex.Authorization/AuthorizationHandlerProvider.cs#L36

It tries to resolve all `AuthorizationHandler<AssertionRequirement>` services, which resulted in no implementations.
The `DependencyInjectionExtensions` registered the `AssertionRequirementHandler` which in turn is an implementation of `AuthorizationHandler<AssertionRequirement>`, but it did so only under the `IAuthorizationHandler` service type.

This PR split this up into registering the `AssertionRequirementHandler` as an own service and then also making it discoverable by both the `AuthorizationHandler<AssertionRequirement>` and `IAuthorizationHandler` types.

Feel free to note anything you want to be done different.

Cheers and sorry for spamming you on Slack :)
